### PR TITLE
[18.0][FIX] stock_picking_group_by_partner_by_carrier: Fixed for delivery slip message and group picking field visibility.

### DIFF
--- a/stock_picking_group_by_partner_by_carrier/__manifest__.py
+++ b/stock_picking_group_by_partner_by_carrier/__manifest__.py
@@ -4,12 +4,13 @@
 {
     "name": "Stock Picking: group by partner and carrier",
     "Summary": "Group sales deliveries moves in 1 picking per partner and carrier",
-    "version": "16.0.1.2.0",
+    "version": "18.0.1.0.0",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "category": "Warehouse",
     "depends": [
         "delivery_procurement_group_carrier",
+        "stock_delivery",
         "stock_picking_group_by_base",
     ],
     "data": [

--- a/stock_picking_group_by_partner_by_carrier/models/stock_move.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_move.py
@@ -3,9 +3,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from collections import namedtuple
-from itertools import groupby
 
 from odoo import api, fields, models
+from odoo.tools import groupby
 
 
 class StockMove(models.Model):
@@ -49,9 +49,7 @@ class StockMove(models.Model):
         return result
 
     def _assign_picking_post_process(self, new=False):
-        moves_by_picking = groupby(
-            sorted(self, key=lambda m: m.picking_id.id), key=lambda m: m.picking_id
-        )
+        moves_by_picking = groupby(self, key=lambda m: m.picking_id)
         for picking, imoves in moves_by_picking:
             merged = picking._merge_procurement_groups()
             if merged:
@@ -64,10 +62,10 @@ class StockMove(models.Model):
     def _on_assign_picking_message_link(self):
         sales = self.sale_line_id.order_id
         if sales:
-            self.picking_id.message_post_with_view(
+            self.picking_id.message_post_with_source(
                 "mail.message_origin_link",
-                values={"self": self.picking_id, "origin": sales, "edit": True},
-                subtype_id=self.env.ref("mail.mt_note").id,
+                render_values={"self": self.picking_id, "origin": sales, "edit": True},
+                subtype_xmlid="mail.mt_note",
             )
 
     def _search_picking_for_assignation_domain(self):
@@ -84,7 +82,8 @@ class StockMove(models.Model):
 
         grouping_domain = self._assign_picking_group_domain()
 
-        return domain + grouping_domain
+        res = domain + grouping_domain
+        return res
 
     # TODO: this part and everything related to generic grouping
     # should be split into `stock_picking_group_by` module.
@@ -100,8 +99,6 @@ class StockMove(models.Model):
             domain += [
                 ("carrier_id", "=", self.group_id.carrier_id.id),
             ]
-        else:
-            domain += [("carrier_id", "=", False)]
         if self.env.context.get("picking_no_copy_if_can_group"):
             # we are in the context of the creation of a backorder:
             # don't consider the current move's picking
@@ -114,8 +111,11 @@ class StockMove(models.Model):
         By default the move type is taken from the procurement group.
         Override to customize this behavior.
         """
-        # avoid mixing picking policies
-        return [("move_type", "=", self.group_id.move_type)]
+        if self.group_id.move_type:
+            # avoid mixing picking policies
+            return [("move_type", "=", self.group_id.move_type)]
+
+        return []
 
     def _key_assign_picking(self):
         return (

--- a/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
+++ b/stock_picking_group_by_partner_by_carrier/models/stock_picking.py
@@ -111,7 +111,7 @@ class StockPicking(models.Model):
     def _prepare_merge_procurement_group_values(self, move_groups):
         """Build a new procurement group that is the merge of given procurement
         group."""
-        sales = move_groups.sale_id
+        sales = move_groups.sale_id + move_groups.sale_ids
         partners = move_groups.sale_id.partner_id
         name = _("Merged procurement")
         if partners:
@@ -119,13 +119,13 @@ class StockPicking(models.Model):
                 "Merged procurement for partners: %(partners_name)s",
                 partners_name=", ".join(partners.mapped("display_name")),
             )
-        return {"sale_ids": [(6, 0, sales.ids)], "name": name}
+        return {"sale_ids": [(6, 0, sales.ids)], "name": name, "sale_id": False}
 
     def _merge_procurement_groups(self):
         self.ensure_one()
         if self._is_grouping_disabled():
             return False
-        if self.picking_type_id.code != "outgoing":
+        if not self.picking_type_id.group_pickings:
             return False
         group_pickings = self.move_ids.group_id.picking_ids.filtered(
             # Do no longer modify a printed or done transfer: they are
@@ -222,7 +222,7 @@ class StockPicking(models.Model):
         self.ensure_one()
         moves = self._get_sorted_moves()
         if not self._delivery_report_state_is_done():
-            moves = moves.filtered("reserved_availability")
+            moves = moves.filtered("quantity")
 
         if len(moves.mapped("sale_line_id.order_id")) > 1:
             grouped_moves = self._group_moves_by_order(moves)
@@ -248,7 +248,7 @@ class StockPicking(models.Model):
                 return sales_and_moves
             else:
                 sales_and_moves = self.env["stock.move.line"]
-                fake_record["reserved_uom_qty"] = fake_record.pop("product_uom_qty")
+                fake_record["quantity"] = fake_record.pop("product_uom_qty")
                 fake_record["product_uom_id"] = fake_record.pop("product_uom")
                 for sale, sale_moves in grouped_moves:
                     if sale:

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.py
@@ -31,7 +31,7 @@ class DeliverySlipReport(models.AbstractModel):
     def _get_sale_data(self, line, moves, picking, qty, uom):
         return {
             "is_header": False,
-            "concept": line.product_id.name_get()[0][-1],
+            "concept": line.product_id.display_name,
             "qty": float_round(qty, precision_rounding=uom.rounding),
             "product": line.product_id,
             "uom": uom,
@@ -52,7 +52,7 @@ class DeliverySlipReport(models.AbstractModel):
         for sale in picking.group_id.sale_ids.sorted(key=lambda s: s.id):
             order_name = sale.get_name_for_delivery_line()
             for line in sale.order_line.filtered(
-                lambda l: not l.display_type and l.product_id.type != "service"
+                lambda x: not x.display_type and x.product_id.type != "service"
             ):
                 moves = stock_move.search(
                     [("sale_line_id", "=", line.id), ("picking_id", "=", picking.id)],

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -73,23 +73,25 @@
             <attribute name="t-if">False</attribute>
         </xpath>
 
-        <!-- Remove "All items could not be shipped..." sentence
-            Substitute it by a message indicating if all goods have been delivered. -->
-        <xpath
-            expr='//div[@t-if="not (o.backorder_ids and backorders)"]'
-            position="after"
-        >
-            <t
-                t-elif="o.picking_type_id.code == 'outgoing' and get_remaining_to_deliver"
-            >
+        <xpath expr="//p[hasclass('mt-5')]/.." position="attributes">
+            <attribute name="t-if">False</attribute>
+            <attribute name="name">stock_backorder_block</attribute>
+        </xpath>
+        <xpath expr='//div[@name="stock_backorder_block"]' position="after">
+            <t t-if="o.picking_type_id.code == 'outgoing' and get_remaining_to_deliver">
                 <t t-set="remainings" t-value="get_remaining_to_deliver(o)" />
-                <t t-if="not remainings">
+                <t
+                    t-if="not remainings and all(q.product_uom_qty == q.quantity for q in o.move_ids)"
+                >
                     <p
                         class="remaining-to-deliver-separator"
                     >All ordered items have been delivered.</p>
                 </t>
                 <t t-else="">
-                    <p class="remaining-to-deliver-separator">Remaining to deliver:</p>
+                    <p
+                        t-if="o.state == 'done'"
+                        class="remaining-to-deliver-separator"
+                    >Remaining to deliver:</p>
                     <table class="table table-sm" name="remaining_to_deliver_table">
                         <tbody>
                             <tr t-foreach="remainings" t-as="remaining">
@@ -103,8 +105,7 @@
                                     <t t-if="not remaining['is_header']">
                                         <span
                                             t-esc="remaining['qty']"
-                                            t-options="{'widget': 'float',
-                                                          'precision': rounding_to_precision(remaining['uom'].rounding)}"
+                                            t-options="{'widget': 'float',                                                           'precision': rounding_to_precision(remaining['uom'].rounding)}"
                                         />
                                         <span
                                             class="remaining_uom_name"

--- a/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
+++ b/stock_picking_group_by_partner_by_carrier/report/report_delivery_slip.xml
@@ -75,12 +75,13 @@
 
         <!-- Remove "All items could not be shipped..." sentence
             Substitute it by a message indicating if all goods have been delivered. -->
-        <xpath expr='//t[@t-if="o.backorder_ids and backorders"]' position="attributes">
-            <attribute name="t-if">False</attribute>
-            <attribute name="name">stock_backorder_block</attribute>
-        </xpath>
-        <xpath expr='//t[@name="stock_backorder_block"]' position="after">
-            <t t-if="o.picking_type_id.code == 'outgoing' and get_remaining_to_deliver">
+        <xpath
+            expr='//div[@t-if="not (o.backorder_ids and backorders)"]'
+            position="after"
+        >
+            <t
+                t-elif="o.picking_type_id.code == 'outgoing' and get_remaining_to_deliver"
+            >
                 <t t-set="remainings" t-value="get_remaining_to_deliver(o)" />
                 <t t-if="not remainings">
                     <p
@@ -143,7 +144,7 @@
             <attribute name="t-if">move_line.id</attribute>
         </xpath>
 
-        <xpath expr='//span[@t-field="move_line.qty_done"]' position="attributes">
+        <xpath expr='//span[@t-field="move_line.quantity"]' position="attributes">
             <attribute name="t-if">move_line.id</attribute>
         </xpath>
 
@@ -167,13 +168,13 @@
 
         <!-- Replace the customer refs with the one based on the move line displayed -->
         <xpath
-            expr='//p[@t-field="o.sudo().sale_id.client_order_ref"]'
+            expr='//div[@t-field="o.sudo().sale_id.client_order_ref"]'
             position="attributes"
         >
             <attribute name="t-if">False</attribute>
         </xpath>
         <xpath
-            expr='//p[@t-field="o.sudo().sale_id.client_order_ref"]'
+            expr='//div[@t-field="o.sudo().sale_id.client_order_ref"]'
             position="after"
         >
             <p class="m-0">

--- a/stock_picking_group_by_partner_by_carrier/tests/common.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/common.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo.tests.common import Form
+from odoo.tests import Form
 
 
 class TestGroupByBase:
@@ -30,7 +30,12 @@ class TestGroupByBase:
         quants = self.env["stock.quant"]._gather(product, location, strict=True)
         # this method adds the quantity to the current quantity, so remove it
         quantity -= sum(quants.mapped("quantity"))
-        self.env["stock.quant"]._update_available_quantity(product, location, quantity)
+        if quantity <= 0:
+            quants.unlink()
+        else:
+            self.env["stock.quant"]._update_available_quantity(
+                product, location, quantity
+            )
 
     def _set_line(self, sale_form, amount=10.0):
         with sale_form.order_line.new() as line_form:
@@ -61,9 +66,10 @@ class TestGroupByBase:
                 .create({"carrier_id": carrier_id.id, "order_id": sale.id})
             )
             choose_delivery_carrier.button_confirm()
+            sale.invalidate_recordset(fnames=["carrier_id"])
         return sale
 
     def _validate_transfer(self, picking):
-        for move_line in picking.move_line_ids:
-            move_line.qty_done = move_line.reserved_uom_qty
+        for move_line in picking.move_ids:
+            move_line.picked = True
         picking._action_done()

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping.py
@@ -2,11 +2,12 @@
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.fields import first
-from odoo.tests.common import Form, TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 from .common import TestGroupByBase
 
 
+@tagged("post_install", "-at_install")
 class TestGroupBy(TestGroupByBase, TransactionCase):
     def test_sale_stock_merge_same_partner_no_carrier(self):
         """2 sale orders for the same partner, without carrier
@@ -123,7 +124,8 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         so2.action_confirm()
         pick = so1.picking_ids
         move = first(pick.move_ids)
-        move.quantity_done = 5
+        move.quantity = 5
+        move.picked = True
         pick.with_context(cancel_backorder=False)._action_done()
         so2.invalidate_recordset()
         self.assertTrue(so2.picking_ids & so1.picking_ids)
@@ -187,49 +189,35 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
     def test_delivery_multi_step(self):
         """the warehouse uses pick + ship
 
-        -> shippings are grouped, pickings are not"""
+        -> shippings are grouped, pickings are not
+        """
         self.warehouse.delivery_steps = "pick_ship"
         so1 = self._get_new_sale_order(carrier=self.carrier1)
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 3)
-        self.assertEqual(len(so2.picking_ids), 3)
-        self.assertEqual(so1.picking_ids, so2.picking_ids)
+        # 18.0 now uses push rules for multi-step shipping
+        # validate that we don't merge the pick step
+        self.assertEqual(len(so1.picking_ids), 1)
+        self.assertEqual(len(so2.picking_ids), 1)
+
+        # complete the picking steps
+        for move_id in so1.picking_ids.move_ids | so2.picking_ids.move_ids:
+            move_id._set_quantity_done(move_id.product_uom_qty)
+            move_id.picked = True
+
+        so1.picking_ids._action_done()
+        so2.picking_ids._action_done()
+
+        self.assertEqual(len(so1.picking_ids), 2)
+        self.assertEqual(len(so2.picking_ids), 2)
+
         # ship should be shared between so1 and so2
         ships = (so1.picking_ids | so2.picking_ids).filtered(
             lambda p: p.picking_type_code == "outgoing"
         )
         self.assertEqual(len(ships), 1)
         self.assertEqual(ships.picking_type_id, self.warehouse.out_type_id)
-        # but not picks
-        # Note: When grouping the ships, all pulled internal moves should also
-        # be regrouped but this is currently not supported by this module. You
-        # need the stock_available_to_promise_release module to have this
-        # feature
-        picks = so1.picking_ids - ships
-        self.assertEqual(len(picks), 2)
-        self.assertEqual(picks.picking_type_id, self.warehouse.pick_type_id)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so1.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_ids.group_id)
-        # Add a line to so1
-        self.assertEqual(len(ships.move_ids), 2)
-        sale_form = Form(so1)
-        self._set_line(sale_form, 4)
-        sale_form.save()
-        self.assertEqual(len(ships.move_ids), 3)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so1.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so1.picking_ids.move_ids.group_id)
-        # Add a line to so2
-        self.assertEqual(len(ships.move_ids), 3)
-        self._set_line(sale_form, 4)
-        sale_form.save()
-        self.assertEqual(len(ships.move_ids), 4)
-        # the group is the same on the move lines and picking
-        self.assertEqual(len(so2.picking_ids.group_id), 1)
-        self.assertEqual(so1.picking_ids.group_id, so2.picking_ids.move_ids.group_id)
 
     def test_delivery_multi_step_group_pick(self):
         """the warehouse uses pick + ship (with grouping enabled on pick)
@@ -246,17 +234,29 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
             self.warehouse.pick_type_id.default_location_dest_id,
             {"warehouse_id": self.warehouse},
         )
-        rule.propagate_carrier = False
+        rule.propagate_carrier = True
         self.warehouse.pick_type_id.group_pickings = True
         so1 = self._get_new_sale_order(carrier=self.carrier1)
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 2)
-        self.assertEqual(len(so2.picking_ids), 2)
-        # ship & pick should be shared between so1 and so2
+
+        self.assertEqual(so1.picking_ids.partner_id, so2.picking_ids.partner_id)
+
+        # 18.0 now uses push rules for multi-step shipping
+        # validate that we HAVE merged the pick step
+        self.assertEqual(len(so1.picking_ids), 1)
+        self.assertEqual(len(so2.picking_ids), 1)
         self.assertEqual(so1.picking_ids, so2.picking_ids)
-        transfers = so1.picking_ids
+
+        # validate the pick steps
+        for move_id in so1.picking_ids.move_ids:
+            move_id._set_quantity_done(move_id.product_uom_qty)
+            move_id.picked = True
+
+        so1.picking_ids._action_done()
+
+        transfers = so1.picking_ids | so2.picking_ids
         self.assertEqual(len(transfers), 2)
         ships = transfers.filtered(
             lambda o: o.picking_type_id == self.warehouse.out_type_id
@@ -286,10 +286,17 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         ships = (so1.picking_ids | so2.picking_ids).filtered(
             lambda p: p.picking_type_code == "outgoing"
         )
-        pick1 = so1.order_line.move_ids.move_orig_ids.picking_id
-        pick2 = so2.order_line.move_ids.move_orig_ids.picking_id
+        pick1 = so1.picking_ids.filtered(
+            lambda p: p.picking_type_id == self.warehouse.pick_type_id
+        )
+        pick2 = so2.picking_ids.filtered(
+            lambda p: p.picking_type_id == self.warehouse.pick_type_id
+        )
+
+        self.assertEqual(len(pick1 | pick2), 2)
+
         so1._action_cancel()
-        self.assertEqual(ships.state, "waiting")
+        self.assertFalse(ships)
         self.assertEqual(pick1.state, "cancel")
         self.assertEqual(pick2.state, "confirmed")
 
@@ -304,17 +311,18 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
             {"warehouse_id": self.warehouse},
         )
         rule.propagate_carrier = False
+        self.warehouse.pick_type_id.group_pickings = False
         so1 = self._get_new_sale_order(carrier=self.carrier1)
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        ships = (so1.picking_ids | so2.picking_ids).filtered(
-            lambda p: p.picking_type_code == "outgoing"
+        pick1 = so1.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
         )
-        pick1 = so1.order_line.move_ids.move_orig_ids.picking_id
-        pick2 = so2.order_line.move_ids.move_orig_ids.picking_id
+        pick2 = so2.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
+        )
         so2._action_cancel()
-        self.assertEqual(ships.state, "waiting")
         self.assertEqual(pick1.state, "confirmed")
         self.assertEqual(pick2.state, "cancel")
 
@@ -343,9 +351,8 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         pick = transfers.filtered(
             lambda o: o.picking_type_id == self.warehouse.pick_type_id
         )
-        self.assertEqual(len(ship), 1)
+        self.assertEqual(len(ship), 0)
         self.assertEqual(len(pick), 1)
-        self.assertEqual(ship.state, "waiting")
         self.assertEqual(pick.state, "confirmed")
 
     def test_delivery_multi_step_group_pick_cancel_so2(self):
@@ -373,9 +380,8 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         pick = transfers.filtered(
             lambda o: o.picking_type_id == self.warehouse.pick_type_id
         )
-        self.assertEqual(len(ship), 1)
+        self.assertEqual(len(ship), 0)
         self.assertEqual(len(pick), 1)
-        self.assertEqual(ship.state, "waiting")
         self.assertEqual(pick.state, "confirmed")
 
     def test_delivery_multi_step_cancel_so1_create_so3(self):
@@ -393,16 +399,18 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        ships = (so1.picking_ids | so2.picking_ids).filtered(
-            lambda p: p.picking_type_code == "outgoing"
+        pick2 = so2.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
         )
         so1._action_cancel()
         so3 = self._get_new_sale_order(amount=12, carrier=self.carrier1)
         so3.action_confirm()
-        self.assertTrue(ships in so3.picking_ids)
-        pick3 = so3.order_line.move_ids.move_orig_ids.picking_id
+        pick3 = so3.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
+        )
         self.assertEqual(len(pick3), 1)
         self.assertEqual(pick3.state, "confirmed")
+        self.assertNotEqual(pick2, pick3)
 
     def test_delivery_mult_step_cancelling_sale_order1_before_create_order2(self):
         """1st sale order is cancelled
@@ -453,8 +461,7 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         move1 = picking.move_ids.filtered(
             lambda line: line.sale_line_id.order_id == so1
         )
-        line1 = move1.move_line_ids
-        line1.qty_done = line1.reserved_uom_qty
+        move1.picked = True
         picking._action_done()
 
         backorder = picking.backorder_ids
@@ -492,8 +499,45 @@ class TestGroupBy(TestGroupByBase, TransactionCase):
         )
         picking.action_assign()
         line = first(picking.move_ids).move_line_ids
-        line.qty_done = line.reserved_uom_qty / 2
+        line.quantity = line.quantity / 2
+        line.picked = True
         picking._action_done()
         self.assertEqual(picking.state, "done")
         self.assertTrue(picking.backorder_ids)
         self.assertNotEqual(picking, picking.backorder_ids)
+
+    def test_merged_procurement_link_to_sale(self):
+        """
+        When a merged procurement group is created, it should not be linked to the
+        original sales order. Linking it would cause any moves manually added to the
+        delivery picking to be associated with that sales order.
+        """
+        so1 = self._get_new_sale_order()
+        so2 = self._get_new_sale_order(amount=11)
+        so1.action_confirm()
+        so2.action_confirm()
+        group = so1.picking_ids.group_id
+        moves = so1.picking_ids.move_ids
+        self.env["procurement.group"].run(
+            [
+                self.env["procurement.group"].Procurement(
+                    self.product,
+                    5.0,
+                    self.product.uom_id,
+                    self.partner.property_stock_customer,
+                    "Test 1",
+                    "Test 1",
+                    self.env.company,
+                    {"group_id": group, "route_ids": self.warehouse.delivery_route_id},
+                )
+            ]
+        )
+        self._update_qty_in_location(so1.picking_ids.location_id, self.product, 100)
+        new_move = so1.picking_ids.move_ids - moves
+        so1.picking_ids.action_assign()
+        for move_id in so1.picking_ids.move_ids:
+            move_id.picked = True
+        so1.picking_ids._action_done()
+        self.assertFalse(new_move.sale_line_id)
+        self.assertFalse(group.sale_id)
+        self.assertEqual(group.sale_ids, so1 + so2)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_grouping_disable_on_partner.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_grouping_disable_on_partner.py
@@ -64,7 +64,8 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         so2.action_confirm()
         pick = so1.picking_ids
         move = first(pick.move_ids)
-        move.quantity_done = 5
+        move.quantity = 5
+        move.picked = True
         pick.with_context(cancel_backorder=False)._action_done()
         self.assertFalse(so2.picking_ids & so1.picking_ids)
         self.assertEqual(so2.picking_ids.sale_ids, so2)
@@ -125,6 +126,18 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
+        # pick steps should not be merged
+        self.assertEqual(len(so1.picking_ids), 1)
+        self.assertEqual(len(so2.picking_ids), 1)
+        # ship or pick should not be shared between so1 and so2
+        self.assertFalse(so1.picking_ids & so2.picking_ids)
+        for move_id in so1.picking_ids.move_ids | so2.picking_ids.move_ids:
+            move_id.picked = True
+            move_id.quantity = move_id.product_uom_qty
+        so1.picking_ids._action_done()
+        so2.picking_ids._action_done()
+
+        # pick steps should not be merged
         self.assertEqual(len(so1.picking_ids), 2)
         self.assertEqual(len(so2.picking_ids), 2)
         # ship or pick should not be shared between so1 and so2
@@ -142,8 +155,8 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 2)
-        self.assertEqual(len(so2.picking_ids), 2)
+        self.assertEqual(len(so1.picking_ids), 1)
+        self.assertEqual(len(so2.picking_ids), 1)
         # ship or pick should not be shared between so1 and so2
         self.assertFalse(so1.picking_ids & so2.picking_ids)
 
@@ -160,9 +173,56 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         so1.action_confirm()
         so2 = self._get_new_sale_order(amount=11, carrier=self.carrier1)
         so2.action_confirm()
-        self.assertEqual(len(so1.picking_ids), 3)
-        self.assertEqual(len(so2.picking_ids), 3)
-        # ship or pick should not be shared between so1 and so2
+        # pick
+        pick1 = so1.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
+        )
+        pick2 = so2.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pick_type_id
+        )
+        self.assertEqual(len(pick1), 1)
+        self.assertEqual(len(pick2), 1)
+        # pick should not be shared between so1 and so2
+        self.assertFalse(pick1 & pick2)
+        for move_id in (pick1 | pick2).move_ids:
+            move_id.picked = True
+            move_id.quantity = move_id.product_uom_qty
+        pick1._action_done()
+        pick2._action_done()
+        # pack
+        pack1 = so1.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pack_type_id
+        )
+        pack2 = so2.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.pack_type_id
+        )
+        self.assertEqual(len(pack1), 1)
+        self.assertEqual(len(pack2), 1)
+        # pack should not be shared between so1 and so2
+        self.assertFalse(pack1 & pack2)
+        for move_id in (pack1 | pack2).move_ids:
+            move_id.picked = True
+            move_id.quantity = move_id.product_uom_qty
+        pack1._action_done()
+        pack2._action_done()
+        # ship
+        ship1 = so1.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.out_type_id
+        )
+        ship2 = so2.picking_ids.filtered(
+            lambda x: x.picking_type_id == self.warehouse.out_type_id
+        )
+        self.assertEqual(len(ship1), 1)
+        self.assertEqual(len(ship2), 1)
+        # ship should not be shared between so1 and so2
+        self.assertFalse(ship1 & ship2)
+        for move_id in (ship1 | ship2).move_ids:
+            move_id.picked = True
+            move_id.quantity = move_id.product_uom_qty
+        ship1._action_done()
+        ship2._action_done()
+
+        # ship or pick or pack should not be shared between so1 and so2
         self.assertFalse(so1.picking_ids & so2.picking_ids)
 
     def test_delivery_multi_step_cancel_so1(self):
@@ -179,8 +239,9 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         self.assertFalse(so1.picking_ids & so2.picking_ids)
         so1._action_cancel()
         self.assertEqual(so1.state, "cancel")
-        self.assertEqual(so1.picking_ids.mapped("state"), ["cancel", "cancel"])
-        self.assertNotEqual(so2.state, "cancel")
+        self.assertEqual(so1.picking_ids.mapped("state"), ["cancel"])
+        self.assertEqual(so1.picking_ids.mapped("state"), ["cancel"])
+        self.assertNotEqual(so2.picking_ids.state, ["cancel"])
 
     def test_delivery_multi_step_cancel_so2(self):
         """the warehouse uses pick + ship. Cancel SO2
@@ -196,8 +257,9 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
         self.assertFalse(so1.picking_ids & so2.picking_ids)
         so2._action_cancel()
         self.assertEqual(so2.state, "cancel")
-        self.assertEqual(so2.picking_ids.mapped("state"), ["cancel", "cancel"])
+        self.assertEqual(so2.picking_ids.mapped("state"), ["cancel"])
         self.assertNotEqual(so1.state, "cancel")
+        self.assertNotEqual(so1.picking_ids.state, ["cancel"])
 
     def test_delivery_multi_step_group_pick_cancel_so1(self):
         """the warehouse uses pick + ship (with grouping enabled on pick)
@@ -288,8 +350,9 @@ class TestGroupByDisabledOnPartner(TestGroupByBase, TransactionCase):
             first(so.order_line).product_uom_qty,
         )
         picking.action_assign()
-        line = first(picking.move_ids).move_line_ids
-        line.qty_done = line.reserved_uom_qty / 2
+        line = first(picking.move_ids)
+        line.quantity = line.product_uom_qty / 2
+        line.picked = True
         picking._action_done()
         self.assertEqual(picking.state, "done")
         self.assertTrue(picking.backorder_ids)

--- a/stock_picking_group_by_partner_by_carrier/tests/test_report.py
+++ b/stock_picking_group_by_partner_by_carrier/tests/test_report.py
@@ -140,10 +140,10 @@ class TestReport(TestGroupByBase, TransactionCase):
         self.assertFalse(res[2].id)
         self.assertTrue(res[3].id)
         # Deliver and test again
-        line = picking.move_ids[0].move_line_ids
-        line.qty_done = line.reserved_uom_qty
-        line = picking.move_ids[1].move_line_ids
-        line.qty_done = line.reserved_uom_qty
+        line = picking.move_ids[0]
+        line.picked = True
+        line = picking.move_ids[1]
+        line.picked = True
         res = picking._action_done()
         self.assertEqual(picking.state, "done")
         res = picking.get_delivery_report_lines()

--- a/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
+++ b/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='first']/group[2]" position="inside">
-                <field name="group_pickings" />
+                <field name="group_pickings" invisible="code != 'outgoing'" />
             </xpath>
         </field>
     </record>

--- a/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
+++ b/stock_picking_group_by_partner_by_carrier/views/stock_picking_type.xml
@@ -5,13 +5,9 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-            <field name="show_reserved" position="after">
-                <field
-                    name="group_pickings"
-                    groups="base.group_no_one"
-                    attrs="{'invisible': [('code', '!=', 'outgoing')]}"
-                />
-            </field>
+            <xpath expr="//group[@name='first']/group[2]" position="inside">
+                <field name="group_pickings" />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/stock_picking_group_by_partner_by_carrier/wizards/stock_picking_merge_wiz.py
+++ b/stock_picking_group_by_partner_by_carrier/wizards/stock_picking_merge_wiz.py
@@ -2,11 +2,9 @@
 # @author Simone Orsi <simahawk@gmail.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from itertools import groupby
-
 from odoo import _, api, exceptions, fields
 from odoo.models import TransientModel
-from odoo.tools import DotDict
+from odoo.tools import DotDict, groupby
 
 
 class StockPickingMergeWizard(TransientModel):
@@ -140,6 +138,6 @@ class StockPickingMergeWizard(TransientModel):
             "res_model": "stock.picking",
             "type": "ir.actions.act_window",
             "view_id": False,
-            "view_mode": "tree,form",
+            "view_mode": "list,form",
             "context": self.env.context,
         }

--- a/stock_picking_group_by_partner_by_carrier/wizards/stock_picking_merge_wiz.xml
+++ b/stock_picking_group_by_partner_by_carrier/wizards/stock_picking_merge_wiz.xml
@@ -5,16 +5,12 @@
         <field name="arch" type="xml">
             <form string="Mass Action for the selected stock picking">
                 <field name="nothing_todo" invisible="1" />
-                <field
-                    name="details"
-                    nolabel="1"
-                    attrs="{'invisible': [('nothing_todo', '=', True)]}"
-                />
+                <field name="details" nolabel="1" invisible="nothing_todo == True" />
                 <group name="valid_pickings">
                     <field name="selected_picking_ids" invisible="1" />
                     <separator string="Valid pickings" colspan="4" />
                     <field name="valid_picking_ids" nolabel="1" colspan="4">
-                        <tree>
+                        <list>
                             <field name="name" />
                             <field name="partner_id" />
                             <field name="carrier_id" />
@@ -22,13 +18,10 @@
                             <field name="location_dest_id" optional="hide" />
                             <field name="picking_type_id" optional="hide" />
                             <field name="state" />
-                        </tree>
+                        </list>
                     </field>
                 </group>
-                <group
-                    name="discarded_pickings"
-                    attrs="{'invisible': [('discarded_picking_ids', '=', False)]}"
-                >
+                <group name="discarded_pickings" invisible="not discarded_picking_ids">
                     <separator
                         string="Some pickings you've selected are discarded"
                         colspan="4"
@@ -42,9 +35,9 @@
                         name="discarded_picking_ids"
                         nolabel="1"
                         colspan="4"
-                        attrs="{'invisible': [('show_discarded_detail', '=', False)]}"
+                        invisible="not show_discarded_detail"
                     >
-                        <tree>
+                        <list>
                             <field name="name" />
                             <field name="partner_id" />
                             <field name="carrier_id" />
@@ -53,7 +46,7 @@
                             <field name="picking_type_id" optional="hide" />
                             <field name="state" />
                             <field name="printed" />
-                        </tree>
+                        </list>
                     </field>
                 </group>
                 <footer>
@@ -62,9 +55,9 @@
                         string="Confirm"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible': [('nothing_todo', '=', True)]}"
+                        invisible="nothing_todo"
                     />
-                    <span attrs="{'invisible': [('nothing_todo', '=', True)]}">or</span>
+                    <span invisible="nothing_todo">or</span>
                     <button string="Cancel" class="oe_link" special="cancel" />
                 </footer>
             </form>


### PR DESCRIPTION
Fix for  https://github.com/OCA/stock-logistics-workflow/pull/1947
- Fixes Implemented:
1) Delivery Slip Message:
    - The message "All ordered items have been delivered." was previously not displayed under any condition. This has been corrected, and the message will appear when the entire quantity of items has been successfully delivered.
    - Steps to Reproduce:
        - Create a Delivery Order for a product with a quantity of 2.
        - Deliver only 1 unit of the product.
        - Generate the Delivery Slip.
        - Result: Observe that the message “All ordered items have been delivered.” does not appear, and the remaining undelivered quantity is still listed.

2) Group Picking Field Visibility:
    - The "Group Picking" field at the Operation Type level was visible across all operation types. It has now been restricted to display only when the operation type is set to Delivery.